### PR TITLE
feat: 회원탈퇴 기능 추가 및 사용자명 표시 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -801,8 +801,7 @@ function AppContent() {
   const handleWithdraw = async () => {
     if (!isLoggedIn) return;
 
-    const confirmed = window.confirm('정말 회원탈퇴 하시겠습니까?
-시간표/위시리스트 데이터가 모두 삭제됩니다.');
+    const confirmed = window.confirm('정말 회원탈퇴 하시겠습니까?\n시간표/위시리스트 데이터가 모두 삭제됩니다.');
     if (!confirmed) return;
 
     const password = window.prompt('본인 확인을 위해 비밀번호를 입력해주세요.');

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -51,6 +51,18 @@ export const AuthProvider = ({ children }) => {
     localStorage.removeItem('user');
   };
 
+  const withdraw = async (password) => {
+    if (!user?.id) throw new Error('로그인 정보가 없습니다.');
+
+    await authAPI.withdraw({
+      userId: String(user.id),
+      password,
+    });
+
+    setUser(null);
+    localStorage.removeItem('user');
+  };
+
   const value = {
     user,
     isLoggedIn: !!user,
@@ -58,6 +70,7 @@ export const AuthProvider = ({ children }) => {
     login,
     register,
     logout,
+    withdraw,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -55,7 +55,7 @@ export const AuthProvider = ({ children }) => {
     if (!user?.id) throw new Error('로그인 정보가 없습니다.');
 
     await authAPI.withdraw({
-      userId: String(user.id),
+      username: user.username,
       password,
     });
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -44,6 +44,18 @@ export const authAPI = {
     });
     return handleResponse(response);
   },
+
+  // 회원탈퇴
+  withdraw: async (data) => {
+    const response = await fetch(`${BASE_URL}/auth/withdraw`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+    return handleResponse(response);
+  },
 };
 
 // 과목 조회 API
@@ -105,8 +117,9 @@ export const wishlistAPI = {
   },
 
   // 위시리스트에서 제거
-  remove: async (userId, subjectId) => {
-    const response = await fetch(`${BASE_URL}/wishlist/remove?userId=${userId}&subjectId=${subjectId}`, {
+  remove: async (userId, subjectId, semester) => {
+    const semParam = semester ? `&semester=${encodeURIComponent(semester)}` : "";
+    const response = await fetch(`${BASE_URL}/wishlist/remove?userId=${userId}&subjectId=${subjectId}${semParam}`, {
       method: 'DELETE',
     });
     return handleResponse(response);
@@ -158,8 +171,9 @@ export const timetableAPI = {
   },
 
   // 시간표에서 과목 제거
-  remove: async (userId, subjectId) => {
-    const response = await fetch(`${BASE_URL}/timetable/remove?userId=${userId}&subjectId=${subjectId}`, {
+  remove: async (userId, subjectId, semester) => {
+    const semParam = semester ? `&semester=${encodeURIComponent(semester)}` : "";
+    const response = await fetch(`${BASE_URL}/timetable/remove?userId=${userId}&subjectId=${subjectId}${semParam}`, {
       method: 'DELETE',
     });
     return handleResponse(response);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -48,7 +48,7 @@ export const authAPI = {
   // 회원탈퇴
   withdraw: async (data) => {
     const response = await fetch(`${BASE_URL}/auth/withdraw`, {
-      method: 'DELETE',
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
## 변경 내용
1) 회원탈퇴 기능 추가
- `authAPI.withdraw` 추가 (`DELETE /api/auth/withdraw`)
- `AuthContext`에 `withdraw(password)` 추가
- 헤더에 `회원탈퇴` 버튼 추가
  - 확인 모달 + 비밀번호 입력(prompt) 후 탈퇴 요청
  - 성공 시 로컬 사용자 세션/데이터(wishlist, timetable) 정리

2) 사용자 이름 표시 개선
- 로그인 헤더 이름 표기를 `user.nickname || user.username`으로 변경
- 닉네임이 비어있는 계정도 `님` 앞에 아이디가 정상 노출되도록 보정

3) API 파라미터 정합성 보강
- wishlist/timetable remove 요청에 `semester`를 함께 전달하도록 변경

## 목적
- 로그인 사용자 식별 표시 누락(“님”만 보이는 현상) 해소
- 계정 라이프사이클(가입/로그인/탈퇴) 완성
- 학기 기반 데이터 처리 일관성 강화
