### PR TITLE
[codex] 관리자 API CSRF 요청 흐름 반영

### DIFF
--- a/src/components/AdminSubjectManager.jsx
+++ b/src/components/AdminSubjectManager.jsx
@@ -242,12 +242,12 @@ const AdminSubjectManager = ({ showToast }) => {
     try {
       const username = sessionStorage.getItem(ADMIN_USERNAME_STORAGE_KEY) || '';
       return {
-        authenticated: false,
+        authenticated: null,
         username
       };
     } catch {
       return {
-        authenticated: false,
+        authenticated: null,
         username: ''
       };
     }
@@ -349,10 +349,11 @@ const AdminSubjectManager = ({ showToast }) => {
     }
   };
 
-  const isAdminAuthenticated = Boolean(adminSession.authenticated);
+  const isAdminSessionChecking = adminSession.authenticated === null;
+  const isAdminAuthenticated = adminSession.authenticated === true;
 
   const requireAdminAuth = () => (
-    isAdminAuthenticated ? '' : '관리자 로그인이 필요합니다.'
+    isAdminSessionChecking ? '관리자 세션을 확인 중입니다.' : isAdminAuthenticated ? '' : '관리자 로그인이 필요합니다.'
   );
 
   const persistAdminSession = (response) => {
@@ -1018,7 +1019,11 @@ const AdminSubjectManager = ({ showToast }) => {
             </p>
           </div>
           <div className="w-full md:w-[360px]">
-            {isAdminAuthenticated ? (
+            {isAdminSessionChecking ? (
+              <div className="flex items-center justify-center rounded-lg border border-slate-200 bg-slate-50 px-3 py-6 text-slate-500">
+                <Loader2 size={18} className="animate-spin" />
+              </div>
+            ) : isAdminAuthenticated ? (
               <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-3 py-2">
                 <div className="flex items-center justify-between gap-3">
                   <div className="min-w-0">

--- a/src/components/AdminSubjectManager.jsx
+++ b/src/components/AdminSubjectManager.jsx
@@ -18,7 +18,7 @@ import { adminAuthAPI, subjectAPI } from '../services/api';
 import { departments, grades } from '../utils/timetableUtils';
 
 const ADMIN_USERNAME_STORAGE_KEY = 'inu_admin_username';
-const ADMIN_CSRF_STORAGE_KEY = 'inu_admin_csrf';
+const LEGACY_ADMIN_CSRF_STORAGE_KEY = 'inu_admin_csrf';
 
 const ADMIN_SUBJECT_TYPES = ['전심', '전핵', '심교', '핵교', '일선', '전기', '기교', '군사학', '교직'];
 const ADMIN_SUBJECT_TYPE_FILTERS = ['전체', ...ADMIN_SUBJECT_TYPES];
@@ -240,18 +240,15 @@ const AdminSubjectManager = ({ showToast }) => {
   const [adminPassword, setAdminPassword] = useState('');
   const [adminSession, setAdminSession] = useState(() => {
     try {
-      const csrfToken = sessionStorage.getItem(ADMIN_CSRF_STORAGE_KEY) || '';
       const username = sessionStorage.getItem(ADMIN_USERNAME_STORAGE_KEY) || '';
       return {
-        authenticated: Boolean(csrfToken),
-        username,
-        csrfToken
+        authenticated: false,
+        username
       };
     } catch {
       return {
         authenticated: false,
-        username: '',
-        csrfToken: ''
+        username: ''
       };
     }
   });
@@ -298,14 +295,13 @@ const AdminSubjectManager = ({ showToast }) => {
         const response = await adminAuthAPI.me();
         if (!isMounted) return;
 
-        const csrfToken = response?.csrfToken || '';
         const username = response?.username || '';
-        if (!response?.authenticated || !csrfToken) {
-          setAdminSession({ authenticated: false, username: '', csrfToken: '' });
+        if (!response?.authenticated) {
+          setAdminSession({ authenticated: false, username: '' });
           return;
         }
 
-        setAdminSession({ authenticated: true, username, csrfToken });
+        setAdminSession({ authenticated: true, username });
         if (username) {
           setAdminUsername(username);
         }
@@ -314,15 +310,15 @@ const AdminSubjectManager = ({ showToast }) => {
           if (username) {
             sessionStorage.setItem(ADMIN_USERNAME_STORAGE_KEY, username);
           }
-          sessionStorage.setItem(ADMIN_CSRF_STORAGE_KEY, csrfToken);
+          sessionStorage.removeItem(LEGACY_ADMIN_CSRF_STORAGE_KEY);
         } catch {
           // 세션 저장이 막혀도 현재 탭의 로그인 상태는 유지한다.
         }
       } catch {
         if (!isMounted) return;
-        setAdminSession({ authenticated: false, username: '', csrfToken: '' });
+        setAdminSession({ authenticated: false, username: '' });
         try {
-          sessionStorage.removeItem(ADMIN_CSRF_STORAGE_KEY);
+          sessionStorage.removeItem(LEGACY_ADMIN_CSRF_STORAGE_KEY);
         } catch {
           // sessionStorage 접근이 막힌 환경에서는 메모리 상태만 초기화한다.
         }
@@ -353,22 +349,20 @@ const AdminSubjectManager = ({ showToast }) => {
     }
   };
 
-  const isAdminAuthenticated = Boolean(adminSession.csrfToken);
-  const adminCsrfToken = adminSession.csrfToken;
+  const isAdminAuthenticated = Boolean(adminSession.authenticated);
 
   const requireAdminAuth = () => (
     isAdminAuthenticated ? '' : '관리자 로그인이 필요합니다.'
   );
 
   const persistAdminSession = (response) => {
-    const csrfToken = response?.csrfToken || '';
     const username = response?.username || adminUsername.trim();
 
-    if (!response?.authenticated || !csrfToken) {
+    if (!response?.authenticated) {
       return false;
     }
 
-    setAdminSession({ authenticated: true, username, csrfToken });
+    setAdminSession({ authenticated: true, username });
     setAdminUsername(username);
     setAdminPassword('');
     setAdminAuthError('');
@@ -377,7 +371,7 @@ const AdminSubjectManager = ({ showToast }) => {
       if (username) {
         sessionStorage.setItem(ADMIN_USERNAME_STORAGE_KEY, username);
       }
-      sessionStorage.setItem(ADMIN_CSRF_STORAGE_KEY, csrfToken);
+      sessionStorage.removeItem(LEGACY_ADMIN_CSRF_STORAGE_KEY);
     } catch {
       notify('관리자 세션 저장에 실패했습니다. 현재 탭에서는 계속 사용할 수 있습니다.', 'warning');
     }
@@ -386,12 +380,12 @@ const AdminSubjectManager = ({ showToast }) => {
   };
 
   const clearAdminSession = () => {
-    setAdminSession({ authenticated: false, username: '', csrfToken: '' });
+    setAdminSession({ authenticated: false, username: '' });
     setAdminPassword('');
     setAdminAuthError('');
 
     try {
-      sessionStorage.removeItem(ADMIN_CSRF_STORAGE_KEY);
+      sessionStorage.removeItem(LEGACY_ADMIN_CSRF_STORAGE_KEY);
     } catch {
       // sessionStorage가 막힌 환경에서는 입력 상태만 초기화한다.
     }
@@ -607,9 +601,9 @@ const AdminSubjectManager = ({ showToast }) => {
     try {
       setIsSaving(true);
       if (mode === 'create') {
-        await subjectAPI.create(payload, adminCsrfToken);
+        await subjectAPI.create(payload);
       } else {
-        await subjectAPI.update(editingSubject.id, payload, adminCsrfToken);
+        await subjectAPI.update(editingSubject.id, payload);
       }
 
       notify(mode === 'create' ? '과목을 생성했습니다.' : '과목을 수정했습니다.');
@@ -655,7 +649,7 @@ const AdminSubjectManager = ({ showToast }) => {
 
     try {
       setIsDeleting(true);
-      await subjectAPI.delete(subjectToDelete.id, adminCsrfToken);
+      await subjectAPI.delete(subjectToDelete.id);
       notify('과목을 삭제했습니다.');
       setSubjectToDelete(null);
       await loadSubjects(currentPage);
@@ -707,7 +701,7 @@ const AdminSubjectManager = ({ showToast }) => {
         semester: importForm.semester.trim(),
         file: importForm.file,
         deactivateMissing: importForm.deactivateMissing
-      }, adminCsrfToken);
+      });
 
       setPreviewResult(response);
       notify('가져오기 미리보기를 불러왔습니다.');
@@ -744,7 +738,7 @@ const AdminSubjectManager = ({ showToast }) => {
         semester: importForm.semester.trim(),
         file: importForm.file,
         deactivateMissing: importForm.deactivateMissing
-      }, adminCsrfToken);
+      });
 
       notify('공식 강의시간표 Excel 반영을 완료했습니다.');
       setIsImportConfirmOpen(false);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -45,14 +45,14 @@ const readCookie = (name) => {
   return cookie ? decodeURIComponent(cookie.slice(encodedName.length)) : '';
 };
 
-const fetchWithUserSession = (url, options = {}) => fetch(url, {
+const fetchWithCredentials = (url, options = {}) => fetch(url, {
   ...options,
   credentials: 'include',
 });
 
 let csrfTokenPromise = null;
 
-const getUserCsrfToken = async () => {
+const getCsrfToken = async () => {
   const cookieToken = readCookie('XSRF-TOKEN');
   if (cookieToken) {
     return cookieToken;
@@ -64,7 +64,7 @@ const getUserCsrfToken = async () => {
 
   csrfTokenPromise = (async () => {
     try {
-      const response = await fetchWithUserSession(`${BASE_URL}/auth/csrf`);
+      const response = await fetchWithCredentials(`${BASE_URL}/auth/csrf`);
       const payload = await handleResponse(response);
       return payload?.token || readCookie('XSRF-TOKEN');
     } finally {
@@ -75,9 +75,9 @@ const getUserCsrfToken = async () => {
   return csrfTokenPromise;
 };
 
-const fetchWithUserCsrf = async (url, options = {}) => {
-  const csrfToken = await getUserCsrfToken();
-  return fetchWithUserSession(url, {
+const fetchWithCsrf = async (url, options = {}) => {
+  const csrfToken = await getCsrfToken();
+  return fetchWithCredentials(url, {
     ...options,
     headers: {
       ...(options.headers || {}),
@@ -86,9 +86,8 @@ const fetchWithUserCsrf = async (url, options = {}) => {
   });
 };
 
-const getAdminHeaders = (csrfToken) => ({
+const getAdminHeaders = () => ({
   'Content-Type': 'application/json',
-  'X-Admin-Csrf': csrfToken || '',
 });
 
 const createSubjectImportFormData = (semester, file, deactivateMissing = false) => {
@@ -139,35 +138,29 @@ export const subjectAPI = {
   },
 
   // 관리자 과목 생성
-  create: async (subjectData, csrfToken) => {
-    const response = await fetch(`${ADMIN_BASE_URL}/subjects`, {
+  create: async (subjectData) => {
+    const response = await fetchWithCsrf(`${ADMIN_BASE_URL}/subjects`, {
       method: 'POST',
-      headers: getAdminHeaders(csrfToken),
-      credentials: 'include',
+      headers: getAdminHeaders(),
       body: JSON.stringify(subjectData),
     });
     return handleResponse(response);
   },
 
   // 관리자 과목 수정
-  update: async (subjectId, subjectData, csrfToken) => {
-    const response = await fetch(`${ADMIN_BASE_URL}/subjects/${subjectId}`, {
+  update: async (subjectId, subjectData) => {
+    const response = await fetchWithCsrf(`${ADMIN_BASE_URL}/subjects/${subjectId}`, {
       method: 'PUT',
-      headers: getAdminHeaders(csrfToken),
-      credentials: 'include',
+      headers: getAdminHeaders(),
       body: JSON.stringify(subjectData),
     });
     return handleResponse(response);
   },
 
   // 관리자 과목 삭제
-  delete: async (subjectId, csrfToken) => {
-    const response = await fetch(`${ADMIN_BASE_URL}/subjects/${subjectId}`, {
+  delete: async (subjectId) => {
+    const response = await fetchWithCsrf(`${ADMIN_BASE_URL}/subjects/${subjectId}`, {
       method: 'DELETE',
-      headers: {
-        'X-Admin-Csrf': csrfToken || '',
-      },
-      credentials: 'include',
     });
     return handleResponse(response);
   },
@@ -178,25 +171,17 @@ export const subjectAPI = {
     return handleResponse(response);
   },
 
-  importPreview: async ({ semester, file, deactivateMissing }, csrfToken) => {
-    const response = await fetch(`${ADMIN_BASE_URL}/subjects/import/preview`, {
+  importPreview: async ({ semester, file, deactivateMissing }) => {
+    const response = await fetchWithCsrf(`${ADMIN_BASE_URL}/subjects/import/preview`, {
       method: 'POST',
-      headers: {
-        'X-Admin-Csrf': csrfToken || '',
-      },
-      credentials: 'include',
       body: createSubjectImportFormData(semester, file, deactivateMissing),
     });
     return handleResponse(response);
   },
 
-  importApply: async ({ semester, file, deactivateMissing }, csrfToken) => {
-    const response = await fetch(`${ADMIN_BASE_URL}/subjects/import/apply`, {
+  importApply: async ({ semester, file, deactivateMissing }) => {
+    const response = await fetchWithCsrf(`${ADMIN_BASE_URL}/subjects/import/apply`, {
       method: 'POST',
-      headers: {
-        'X-Admin-Csrf': csrfToken || '',
-      },
-      credentials: 'include',
       body: createSubjectImportFormData(semester, file, deactivateMissing),
     });
     return handleResponse(response);
@@ -205,28 +190,24 @@ export const subjectAPI = {
 
 export const adminAuthAPI = {
   login: async ({ username, password }) => {
-    const response = await fetch(`${ADMIN_BASE_URL}/auth/login`, {
+    const response = await fetchWithCsrf(`${ADMIN_BASE_URL}/auth/login`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      credentials: 'include',
       body: JSON.stringify({ username, password }),
     });
     return handleResponse(response);
   },
 
   me: async () => {
-    const response = await fetch(`${ADMIN_BASE_URL}/auth/me`, {
-      credentials: 'include',
-    });
+    const response = await fetchWithCredentials(`${ADMIN_BASE_URL}/auth/me`);
     return handleResponse(response);
   },
 
   logout: async () => {
-    const response = await fetch(`${ADMIN_BASE_URL}/auth/logout`, {
+    const response = await fetchWithCsrf(`${ADMIN_BASE_URL}/auth/logout`, {
       method: 'POST',
-      credentials: 'include',
     });
     return handleResponse(response);
   },
@@ -236,7 +217,7 @@ export const adminAuthAPI = {
 export const authAPI = {
   // 회원가입
   register: async (userData) => {
-    const response = await fetchWithUserSession(`${BASE_URL}/auth/register`, {
+    const response = await fetchWithCredentials(`${BASE_URL}/auth/register`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -248,7 +229,7 @@ export const authAPI = {
 
   // 로그인
   login: async (credentials) => {
-    const response = await fetchWithUserSession(`${BASE_URL}/auth/login`, {
+    const response = await fetchWithCredentials(`${BASE_URL}/auth/login`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -259,12 +240,12 @@ export const authAPI = {
   },
 
   me: async () => {
-    const response = await fetchWithUserSession(`${BASE_URL}/auth/me`);
+    const response = await fetchWithCredentials(`${BASE_URL}/auth/me`);
     return handleResponse(response);
   },
 
   logout: async () => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/auth/logout`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/auth/logout`, {
       method: 'POST',
     });
     return handleResponse(response);
@@ -275,7 +256,7 @@ export const authAPI = {
 export const wishlistAPI = {
   // 위시리스트에 과목 추가 (필수 과목 지정 포함)
   add: async (data) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/wishlist/add`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/wishlist/add`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -287,13 +268,13 @@ export const wishlistAPI = {
 
   // 위시리스트 조회
   getByUser: async (userId, semester = '2024-2') => {
-    const response = await fetchWithUserSession(`${BASE_URL}/wishlist/user/${userId}?semester=${semester}`);
+    const response = await fetchWithCredentials(`${BASE_URL}/wishlist/user/${userId}?semester=${semester}`);
     return handleResponse(response);
   },
 
   // 위시리스트에서 제거
   remove: async (userId, subjectId) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/wishlist/remove?userId=${userId}&subjectId=${subjectId}`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/wishlist/remove?userId=${userId}&subjectId=${subjectId}`, {
       method: 'DELETE',
     });
     return handleResponse(response);
@@ -301,7 +282,7 @@ export const wishlistAPI = {
 
   // 우선순위 변경
   updatePriority: async (data) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/wishlist/priority`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/wishlist/priority`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -313,7 +294,7 @@ export const wishlistAPI = {
 
   // 필수 과목 설정 변경
   updateRequired: async (data) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/wishlist/required`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/wishlist/required`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -328,7 +309,7 @@ export const wishlistAPI = {
 export const timetableAPI = {
   // 시간표에 과목 추가
   add: async (data) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/timetable/add`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/timetable/add`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -340,13 +321,13 @@ export const timetableAPI = {
 
   // 개인 시간표 조회
   getByUser: async (userId, semester = '2024-2') => {
-    const response = await fetchWithUserSession(`${BASE_URL}/timetable/user/${userId}?semester=${semester}`);
+    const response = await fetchWithCredentials(`${BASE_URL}/timetable/user/${userId}?semester=${semester}`);
     return handleResponse(response);
   },
 
   // 시간표에서 과목 제거
   remove: async (userId, subjectId) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/timetable/remove?userId=${userId}&subjectId=${subjectId}`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/timetable/remove?userId=${userId}&subjectId=${subjectId}`, {
       method: 'DELETE',
     });
     return handleResponse(response);
@@ -354,7 +335,7 @@ export const timetableAPI = {
 
   // 메모 수정
   updateMemo: async (data) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/timetable/memo`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/timetable/memo`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -369,7 +350,7 @@ export const timetableAPI = {
 export const combinationAPI = {
   // 시간표 자동 조합 생성
   generate: async (data) => {
-    const response = await fetchWithUserCsrf(`${BASE_URL}/timetable-combination/generate`, {
+    const response = await fetchWithCsrf(`${BASE_URL}/timetable-combination/generate`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## 변경 사항
- 관리자 API 요청도 공용 Spring CSRF 토큰 흐름(`XSRF-TOKEN` 쿠키 + `X-XSRF-TOKEN` 헤더)을 사용하도록 변경했습니다.
- 기존 관리자 전용 `X-Admin-Csrf` 헤더 사용을 제거했습니다.
- 관리자 로그인 상태 판단을 `csrfToken` 존재 여부가 아니라 `authenticated` 응답 값 기준으로 정리했습니다.
- 과거 세션 스토리지에 남아 있을 수 있는 `inu_admin_csrf` 값은 복원/로그인/로그아웃 흐름에서 제거하도록 했습니다.

## 배경
백엔드에서 관리자 경로를 Spring Security CSRF 보호 대상으로 편입하면서, 프론트 관리자 화면도 같은 토큰 발급/전송 흐름을 사용해야 합니다.

## 배포 영향
- 백엔드 PR과 함께 배포해야 합니다. 프론트만 먼저 배포하면 현재 운영 백엔드가 `X-Admin-Csrf`를 기대하는 구간에서 관리자 변경 요청이 실패할 수 있습니다.
- 학생 사용자 API 요청은 기존과 동일한 쿠키 기반 세션/CSRF 흐름을 유지합니다.

## 검증
- `npm run build`
- 백엔드 연동 검증: `./gradlew test`, `./gradlew bootJar`