### PR TITLE
서비스 UI 정리와 footer 개발 노트 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -615,9 +615,8 @@ const FilterSelect = ({ value, onChange, active, label, disabled = false, option
       {isOpen && (
         <div className={`select-menu ${optionWrap ? 'select-menu-wide' : ''}`}>
           <div id={listboxId} role="listbox" aria-label={label} className="max-h-64 overflow-y-auto p-1">
-            {options.map(option => {
+            {options.map((option, optionIndex) => {
               const isSelected = String(option.value) === String(value);
-              const optionIndex = options.findIndex(candidate => String(candidate.value) === String(option.value));
               const isActive = optionIndex === activeIndex;
 
               return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useMemo, useEffect, useRef, useCallback, useId } from 'react';
 import { Search, Filter, Plus, Info, ChevronDown, ChevronLeft, ChevronRight, MapPin, Clock, Star, X, ShoppingCart, CalendarDays, AlertTriangle, LogIn, LogOut, Download, Maximize, MessageSquare, Settings, CheckCircle2, XCircle, RotateCcw, SearchX } from 'lucide-react';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import AuthModal from './components/AuthModal';
@@ -296,36 +296,37 @@ const formatScheduleLabel = (course) => {
 };
 
 const CourseRow = ({ course, onAddToTimetable, onAddToWishlist, actionsDisabled = false }) => (
-  <li className="px-4 py-3 transition-colors hover:bg-slate-50/80 sm:px-5 sm:py-2.5">
-    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+  <li className="course-list-row">
+    <div className="grid gap-2.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
       <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-          <span className={`inline-flex flex-shrink-0 items-center rounded-md px-1.5 py-0.5 text-[11px] font-semibold ${course.color} ${course.textColor}`}>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className={`course-type-badge ${course.color} ${course.textColor}`}>
             {course.type}
           </span>
-          <h3 className="min-w-0 truncate text-sm font-semibold text-slate-900" title={course.name}>
+          <h3 className="min-w-0 truncate text-[15px] font-semibold text-slate-900" title={course.name}>
             {course.name}
           </h3>
-          <span className="flex-shrink-0 text-xs font-medium text-slate-400">{course.credits}학점</span>
+          <span className="meta-chip flex-shrink-0">{course.credits}학점</span>
         </div>
-        <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-slate-500">
-          <span className="min-w-0 flex-shrink-[2] truncate">{course.professor} · {course.department}</span>
-          <span className="flex-shrink-0 text-slate-300">·</span>
-          <span className="flex min-w-0 flex-shrink items-center gap-1 font-medium text-slate-600">
+        <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-slate-500">
+          <span className="min-w-0 flex-shrink-[2] truncate">
+            {course.professor} · {course.department}
+          </span>
+          <span className="meta-chip min-w-0 flex-shrink bg-white">
             <Clock size={11} className="flex-shrink-0 text-slate-400" />
             <span className="truncate">{formatScheduleLabel(course)}</span>
           </span>
         </div>
       </div>
 
-      <div className="flex flex-shrink-0 items-center gap-1.5 sm:ml-3">
+      <div className="grid grid-cols-[2.75rem_1fr_1fr] items-center gap-1.5 sm:ml-3 sm:flex sm:flex-shrink-0">
         <a
           href={`https://everytime.kr/lecture/search?keyword=${encodeURIComponent(course.name)}&condition=name`}
           target="_blank"
           rel="noopener noreferrer"
           aria-label={`${course.name} 강의평 보기`}
           title="에브리타임 강의평"
-          className="icon-btn"
+          className="icon-btn h-11 w-11 bg-slate-50/80 ring-1 ring-inset ring-slate-200/70 sm:h-8 sm:w-8"
         >
           <MessageSquare size={15} />
         </a>
@@ -333,7 +334,7 @@ const CourseRow = ({ course, onAddToTimetable, onAddToWishlist, actionsDisabled 
           type="button"
           onClick={() => onAddToWishlist(course)}
           disabled={actionsDisabled}
-          className="btn-secondary h-8 flex-1 px-3 text-[13px] sm:flex-none"
+          className="btn-secondary h-11 flex-1 px-3 text-[13px] sm:h-8 sm:flex-none"
         >
           <ShoppingCart size={13} /> 담기
         </button>
@@ -341,7 +342,7 @@ const CourseRow = ({ course, onAddToTimetable, onAddToWishlist, actionsDisabled 
           type="button"
           onClick={() => onAddToTimetable(course)}
           disabled={actionsDisabled}
-          className="btn-primary h-8 flex-1 px-3 text-[13px] sm:flex-none"
+          className="btn-primary h-11 flex-1 px-3 text-[13px] sm:h-8 sm:flex-none"
         >
           <Plus size={13} /> 추가
         </button>
@@ -351,13 +352,25 @@ const CourseRow = ({ course, onAddToTimetable, onAddToWishlist, actionsDisabled 
 );
 
 const CourseRowSkeleton = () => (
-  <li className="animate-pulse px-4 py-3 sm:px-5">
-    <div className="flex items-center gap-2">
-      <div className="h-4 w-9 rounded-md bg-slate-100" />
-      <div className="h-4 w-44 rounded-md bg-slate-200" />
-      <div className="h-3 w-10 rounded-md bg-slate-100" />
+  <li className="course-list-row animate-pulse">
+    <div className="grid gap-2.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <div className="h-5 w-9 rounded-md bg-slate-100" />
+          <div className="h-5 w-44 rounded-md bg-slate-200" />
+          <div className="h-5 w-10 rounded-md bg-slate-100" />
+        </div>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          <div className="h-5 w-24 rounded-md bg-slate-100 sm:w-36" />
+          <div className="h-5 w-32 rounded-md bg-slate-100 sm:w-48" />
+        </div>
+      </div>
+      <div className="grid grid-cols-[2.75rem_1fr_1fr] gap-1.5 sm:flex">
+        <div className="h-11 rounded-lg bg-slate-100 sm:h-8 sm:w-8" />
+        <div className="h-11 rounded-lg bg-slate-100 sm:h-8 sm:w-14" />
+        <div className="h-11 rounded-lg bg-slate-200 sm:h-8 sm:w-14" />
+      </div>
     </div>
-    <div className="mt-2 h-3 w-56 rounded-md bg-slate-100" />
   </li>
 );
 
@@ -374,16 +387,110 @@ const EmptyResults = ({ onReset }) => (
   </div>
 );
 
-const FilterSelect = ({ value, onChange, active, label, disabled = false, children }) => {
+const developerNoteEntries = [
+  {
+    date: '2026.06.13',
+    title: '검색 화면과 온라인 과목 정리',
+    items: [
+      '검색 결과를 한 줄 리스트 중심으로 정리했습니다.',
+      '온라인 과목을 필터로 찾을 수 있게 하고 표시 문구를 정리했습니다.',
+      '모바일 버튼, 위시리스트, 조합 결과 화면의 터치 영역을 다듬었습니다.',
+    ],
+  },
+  {
+    date: '2026.06.12',
+    title: '로그인과 과목 데이터 관리 개선',
+    items: [
+      '로그인 세션과 개인 시간표 접근 흐름을 더 안전하게 정리했습니다.',
+      '관리자 과목 업로드 흐름을 분리해 다음 학기 데이터 교체를 준비했습니다.',
+      '과목 검색 속도를 안정적으로 유지하기 위한 캐시 적용 방향을 검증했습니다.',
+    ],
+  },
+];
+
+const upcomingDeveloperNotes = [
+  '회원 탈퇴와 개인정보 정리 흐름 검토',
+  '다음 학기 과목 import 전 semester 데이터 정리',
+];
+
+const DeveloperNotesModal = ({ onClose }) => {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-end justify-center bg-slate-950/35 p-0 backdrop-blur-sm sm:items-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="developer-notes-title">
+      <div className="modal-panel max-h-[88vh] w-full overflow-hidden rounded-t-2xl bg-white shadow-2xl shadow-slate-950/15 ring-1 ring-slate-900/10 sm:max-w-xl sm:rounded-2xl">
+        <div className="flex items-start justify-between gap-3 border-b border-slate-100 px-5 py-4">
+          <div>
+            <p className="text-xs font-semibold text-blue-600">서비스 개선 기록</p>
+            <h2 id="developer-notes-title" className="mt-1 text-lg font-bold text-slate-900">방학 개발 노트</h2>
+          </div>
+          <button type="button" onClick={onClose} className="icon-btn h-9 w-9" aria-label="개발 노트 닫기">
+            <X size={17} />
+          </button>
+        </div>
+
+        <div className="max-h-[calc(88vh-4.5rem)] overflow-y-auto px-5 py-4">
+          <ol className="space-y-4">
+            {developerNoteEntries.map((entry) => (
+              <li key={entry.date} className="grid grid-cols-[5.25rem_minmax(0,1fr)] gap-3">
+                <time className="pt-0.5 text-xs font-semibold tabular-nums text-slate-400">{entry.date}</time>
+                <div className="border-l border-slate-200 pl-4">
+                  <h3 className="text-sm font-bold text-slate-900">{entry.title}</h3>
+                  <ul className="mt-2 space-y-1.5">
+                    {entry.items.map((item) => (
+                      <li key={item} className="flex gap-2 text-sm leading-relaxed text-slate-600">
+                        <CheckCircle2 size={14} className="mt-0.5 flex-shrink-0 text-blue-500" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <div className="mt-5 border-t border-slate-100 pt-4">
+            <h3 className="text-sm font-bold text-slate-900">다음에 볼 것</h3>
+            <ul className="mt-2 space-y-1.5">
+              {upcomingDeveloperNotes.map((item) => (
+                <li key={item} className="flex gap-2 text-sm leading-relaxed text-slate-500">
+                  <Info size={14} className="mt-0.5 flex-shrink-0 text-slate-400" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const FilterSelect = ({ value, onChange, active, label, disabled = false, optionWrap = false, children }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const selectId = useId();
   const containerRef = useRef(null);
+  const triggerRef = useRef(null);
+  const optionRefs = useRef([]);
   const options = React.Children.toArray(children)
     .filter(React.isValidElement)
     .map(child => ({
       value: child.props.value,
       label: child.props.children
     }));
-  const selectedOption = options.find(option => String(option.value) === String(value)) || options[0];
+  const selectedIndex = options.findIndex(option => String(option.value) === String(value));
+  const selectedOption = options[selectedIndex] || options[0];
+  const listboxId = `${selectId}-listbox`;
 
   useEffect(() => {
     if (!isOpen) return undefined;
@@ -408,6 +515,16 @@ const FilterSelect = ({ value, onChange, active, label, disabled = false, childr
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const nextIndex = selectedIndex >= 0 ? selectedIndex : 0;
+    setActiveIndex(nextIndex);
+    requestAnimationFrame(() => {
+      optionRefs.current[nextIndex]?.focus();
+    });
+  }, [isOpen, selectedIndex]);
+
   const handleSelect = (nextValue) => {
     if (disabled) return;
     setIsOpen(false);
@@ -416,20 +533,77 @@ const FilterSelect = ({ value, onChange, active, label, disabled = false, childr
     }
   };
 
+  const focusOption = (nextIndex) => {
+    const normalizedIndex = (nextIndex + options.length) % options.length;
+    setActiveIndex(normalizedIndex);
+    optionRefs.current[normalizedIndex]?.focus();
+  };
+
+  const handleTriggerKeyDown = (event) => {
+    if (disabled) return;
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setIsOpen(true);
+    }
+  };
+
+  const handleOptionKeyDown = (event, index, optionValue) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      focusOption(index + 1);
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      focusOption(index - 1);
+      return;
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      focusOption(0);
+      return;
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      focusOption(options.length - 1);
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleSelect(optionValue);
+      triggerRef.current?.focus();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setIsOpen(false);
+      triggerRef.current?.focus();
+    }
+  };
+
   return (
     <div ref={containerRef} className="relative">
       <button
+        ref={triggerRef}
         type="button"
         aria-label={label}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
+        aria-controls={isOpen ? listboxId : undefined}
         disabled={disabled}
+        onKeyDown={handleTriggerKeyDown}
         onClick={() => {
           if (!disabled) {
             setIsOpen(prev => !prev);
           }
         }}
-        className={`field flex items-center justify-between rounded-xl bg-slate-50/70 pr-3 text-left text-[13px] shadow-inner shadow-slate-100/60 hover:bg-white disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400 disabled:shadow-none ${active && !disabled ? 'border-blue-200 bg-blue-50/80 font-medium text-blue-700 shadow-blue-100/50' : 'text-slate-600'}`}
+        className={`field select-trigger ${active && !disabled ? 'select-trigger-active' : 'text-slate-600'}`}
       >
         <span className="truncate">{selectedOption?.label}</span>
         <ChevronDown
@@ -439,21 +613,30 @@ const FilterSelect = ({ value, onChange, active, label, disabled = false, childr
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 right-0 top-[calc(100%+6px)] z-50 overflow-hidden rounded-2xl border border-slate-200 bg-white py-1 shadow-xl shadow-slate-900/10 ring-1 ring-slate-900/5">
-          <div role="listbox" aria-label={label} className="max-h-64 overflow-y-auto p-1">
+        <div className={`select-menu ${optionWrap ? 'select-menu-wide' : ''}`}>
+          <div id={listboxId} role="listbox" aria-label={label} className="max-h-64 overflow-y-auto p-1">
             {options.map(option => {
               const isSelected = String(option.value) === String(value);
+              const optionIndex = options.findIndex(candidate => String(candidate.value) === String(option.value));
+              const isActive = optionIndex === activeIndex;
 
               return (
                 <button
                   key={option.value}
+                  ref={(element) => {
+                    optionRefs.current[optionIndex] = element;
+                  }}
                   type="button"
                   role="option"
                   aria-selected={isSelected}
+                  tabIndex={isActive ? 0 : -1}
+                  title={typeof option.label === 'string' ? option.label : undefined}
                   onClick={() => handleSelect(option.value)}
-                  className={`flex w-full items-center rounded-xl px-3 py-2 text-left text-[13px] transition-colors ${isSelected ? 'bg-blue-50 font-semibold text-blue-700' : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'}`}
+                  onKeyDown={(event) => handleOptionKeyDown(event, optionIndex, option.value)}
+                  className={`select-option ${isSelected ? 'select-option-active' : ''}`}
                 >
-                  <span className="truncate">{option.label}</span>
+                  <span className={optionWrap ? 'break-keep leading-snug' : 'truncate'}>{option.label}</span>
+                  {isSelected && <CheckCircle2 size={14} className="flex-shrink-0 text-blue-500" />}
                 </button>
               );
             })}
@@ -466,7 +649,7 @@ const FilterSelect = ({ value, onChange, active, label, disabled = false, childr
 
 // 메인 애플리케이션 컴포넌트
 function AppContent() {
-  const { user, isLoggedIn, isLoading: authLoading, logout } = useAuth();
+  const { user, isLoggedIn, isLoading: authLoading, logout, createDevSession } = useAuth();
   const [searchTerm, setSearchTerm] = useState('');
   const [showFilters, setShowFilters] = useState(false);
   const [filters, setFilters] = useState({ department: '전체', subjectType: '전체', grade: '전체', credits: '전체', dayOfWeek: '전체', startTime: '전체', endTime: '전체' });
@@ -505,10 +688,13 @@ function AppContent() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showNewUserTutorial, setShowNewUserTutorial] = useState(false);
+  const [isCreatingDevSession, setIsCreatingDevSession] = useState(false);
+  const [showDeveloperNotes, setShowDeveloperNotes] = useState(false);
 
   // 시간표 조합 결과
   const [combinationResults, setCombinationResults] = useState(null);
   const [showCombinationResults, setShowCombinationResults] = useState(false);
+  const [isApplyingCombination, setIsApplyingCombination] = useState(false);
 
   // 목표 학점 설정
   const [targetCredits, setTargetCredits] = useState(18);
@@ -516,6 +702,7 @@ function AppContent() {
   // 희망 공강 요일 설정
   const [freeDays, setFreeDays] = useState([]);
   const wishlistCredits = wishlist.reduce((acc, c) => acc + c.credits, 0);
+  const canCreateDevSession = import.meta.env.DEV && !isLoggedIn;
 
   const showToast = useCallback((message, type = 'success') => {
     setToast({ show: true, message, type });
@@ -990,6 +1177,14 @@ function AppContent() {
 
   // 시간표 조합 선택 핸들러
   const handleSelectCombination = async (selectedCombination) => {
+    if (!user) {
+      showToast('로그인 후 시간표 조합을 적용할 수 있어요.', 'warning');
+      return;
+    }
+
+    if (isApplyingCombination) return;
+
+    setIsApplyingCombination(true);
     try {
       console.log('🔄 조합 선택:', selectedCombination);
 
@@ -1023,12 +1218,40 @@ function AppContent() {
       showToast('시간표에 선택한 조합이 적용되었습니다!');
     } catch (error) {
       console.error('❌ 조합 선택 오류:', error);
-      showToast('시간표 적용 중 오류가 발생했습니다.', 'warning');
+      try {
+        const latestTimetable = await timetableAPI.getByUser(user.id, CURRENT_SEMESTER);
+        const latestCourses = latestTimetable.map((subject, index) => formatCourse(subject, index));
+        setTimetable(latestCourses);
+        showToast('시간표 적용 중 오류가 발생해 서버 상태로 다시 동기화했어요.', 'warning');
+      } catch (syncError) {
+        console.error('❌ 시간표 재동기화 실패:', syncError);
+        showToast('시간표 적용 중 오류가 발생했습니다. 새로고침 후 다시 확인해주세요.', 'warning');
+      }
+    } finally {
+      setIsApplyingCombination(false);
     }
   };
 
   const handleLogin = () => {
     setShowAuthModal(true);
+  };
+
+  const handleCreateDevSession = async () => {
+    if (isCreatingDevSession) return;
+
+    setIsCreatingDevSession(true);
+    try {
+      const payload = await createDevSession({
+        semester: CURRENT_SEMESTER,
+        seedWishlist: true,
+      });
+      const seededCount = payload?.seededWishlistCount || payload?.wishlistCount || 0;
+      showToast(`디자인 QA 세션을 열었어요. 위시리스트 ${seededCount}개를 준비했습니다.`);
+    } catch (error) {
+      showToast(`디자인 QA 세션 생성 실패: ${error.message}`, 'warning');
+    } finally {
+      setIsCreatingDevSession(false);
+    }
   };
 
   const handleLogout = () => {
@@ -1451,6 +1674,7 @@ function AppContent() {
   const hasResultPagination = totalPages > 1;
   const canGoToPreviousPage = hasResultPagination && currentPage > 0 && !isLoading;
   const canGoToNextPage = hasResultPagination && currentPage < totalPages - 1 && !isLoading;
+  const hasBlockingOverlay = showWishlistModal || showNewUserTutorial || showDeveloperNotes;
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -1500,36 +1724,42 @@ function AppContent() {
         onClearAll={handleClearAllTimetable}
         onExportPDF={handleExportTimetablePDF}
       />
+      {showDeveloperNotes && (
+        <DeveloperNotesModal onClose={() => setShowDeveloperNotes(false)} />
+      )}
 
       {showCombinationResults && combinationResults && (
         <TimetableCombinationResults
           results={combinationResults}
           onClose={() => setShowCombinationResults(false)}
           onSelectCombination={handleSelectCombination}
+          isApplying={isApplyingCombination}
         />
       )}
 
       <header
-        aria-hidden={showWishlistModal || showNewUserTutorial}
-        inert={showWishlistModal || showNewUserTutorial ? '' : undefined}
+        aria-hidden={hasBlockingOverlay}
+        inert={hasBlockingOverlay ? '' : undefined}
         className="sticky top-0 z-40 border-b border-slate-200/80 bg-white/90 backdrop-blur"
       >
         <div className="mx-auto flex h-14 max-w-7xl items-center justify-between gap-3 px-4 md:px-8">
-          <a href="/" className="flex min-w-0 items-center gap-2">
-            <span className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg bg-blue-600 text-white shadow-sm">
-              <CalendarDays size={17} />
-            </span>
-            <span className="truncate text-[15px] font-bold tracking-tight text-slate-900">INU 시간표</span>
-          </a>
+          <div className="flex min-w-0 items-center gap-1 sm:gap-3">
+            <a href="/" className="flex flex-shrink-0 items-center gap-2">
+              <span className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg bg-blue-600 text-white shadow-sm">
+                <CalendarDays size={17} />
+              </span>
+              <span className="hidden text-[15px] font-bold tracking-tight text-slate-900 sm:inline">INU 시간표</span>
+            </a>
+          </div>
           <div className="flex flex-shrink-0 items-center gap-2">
             <button
               type="button"
               onClick={handleShowTimetableList}
-              className="icon-btn relative lg:hidden"
+              className="icon-btn relative h-10 w-10 lg:hidden"
               title="내 시간표 보기"
               aria-label={`내 시간표 보기${timetable.length > 0 ? `, ${timetable.length}개 과목` : ''}`}
             >
-              <CalendarDays size={15} />
+              <CalendarDays size={16} />
               {timetable.length > 0 && (
                 <span className="absolute -right-1 -top-1 grid h-4 min-w-[16px] place-items-center rounded-full bg-blue-600 px-1 text-[10px] font-bold leading-none text-white ring-2 ring-white">
                   {timetable.length}
@@ -1542,12 +1772,12 @@ function AppContent() {
                   <p className="text-[13px] font-semibold leading-tight text-slate-900">{user.nickname}님</p>
                   <p className="text-[11px] leading-tight text-slate-500">{user.major} {user.grade}학년</p>
                 </div>
-                <button onClick={handleLogout} className="btn-ghost h-8 px-2.5 text-[13px]">
+                <button onClick={handleLogout} className="btn-ghost h-10 px-3 text-[13px] md:h-8 md:px-2.5">
                   <LogOut size={14} /> 로그아웃
                 </button>
               </>
             ) : (
-              <button onClick={handleLogin} className="btn-primary h-8 px-3 text-[13px]">
+              <button onClick={handleLogin} className="btn-primary h-10 px-3 text-[13px] md:h-8">
                 <LogIn size={14} /> 로그인
               </button>
             )}
@@ -1556,10 +1786,39 @@ function AppContent() {
       </header>
 
       <div
-        aria-hidden={showWishlistModal || showNewUserTutorial}
-        inert={showWishlistModal || showNewUserTutorial ? '' : undefined}
+        aria-hidden={hasBlockingOverlay}
+        inert={hasBlockingOverlay ? '' : undefined}
         className="mx-auto max-w-7xl px-4 py-4 md:px-8 md:py-6"
       >
+        <>
+        {canCreateDevSession && (
+          <section className="mb-3 flex flex-col gap-2 rounded-xl border border-blue-200 bg-blue-50 px-3 py-2.5 text-blue-900 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg bg-white text-blue-600 ring-1 ring-blue-200">
+                <Settings size={15} />
+              </span>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold">디자인 QA 세션</p>
+                <p className="truncate text-xs text-blue-700">테스트 사용자 · 샘플 위시리스트</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={handleCreateDevSession}
+              disabled={isCreatingDevSession}
+              className="btn-primary h-10 w-full bg-blue-700 px-4 text-sm hover:bg-blue-600 sm:w-auto"
+            >
+              {isCreatingDevSession ? (
+                <>
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  준비 중
+                </>
+              ) : (
+                '테스트 세션 시작'
+              )}
+            </button>
+          </section>
+        )}
 
         {/* 검색 바 */}
         <section aria-label="과목 검색" className="card p-3 md:p-4">
@@ -1591,6 +1850,7 @@ function AppContent() {
               label="학과 필터"
               value={filters.department}
               active={filters.department !== '전체'}
+              optionWrap
               onChange={(e) => setFilters(prev => ({ ...prev, department: e.target.value }))}
             >
               {departments.map(dept => (
@@ -1703,7 +1963,7 @@ function AppContent() {
                       onClick={() => handlePageChange(currentPage - 1)}
                       disabled={!canGoToPreviousPage}
                       aria-label="이전 페이지"
-                      className="icon-btn h-7 w-7 disabled:opacity-40"
+                      className="icon-btn h-10 w-10 disabled:opacity-40 sm:h-7 sm:w-7"
                     >
                       <ChevronLeft size={15} />
                     </button>
@@ -1715,7 +1975,7 @@ function AppContent() {
                       onClick={() => handlePageChange(currentPage + 1)}
                       disabled={!canGoToNextPage}
                       aria-label="다음 페이지"
-                      className="icon-btn h-7 w-7 disabled:opacity-40"
+                      className="icon-btn h-10 w-10 disabled:opacity-40 sm:h-7 sm:w-7"
                     >
                       <ChevronRight size={15} />
                     </button>
@@ -1724,7 +1984,7 @@ function AppContent() {
               </div>
 
               {isLoading ? (
-                <ul aria-label="검색 결과 불러오는 중" className="divide-y divide-slate-100">
+                <ul aria-label="검색 결과 불러오는 중" className="course-list">
                   {Array.from({ length: 8 }).map((_, index) => (
                     <CourseRowSkeleton key={index} />
                   ))}
@@ -1734,7 +1994,7 @@ function AppContent() {
               ) : (
                 <ul
                   ref={resultsListRef}
-                  className="divide-y divide-slate-100 lg:max-h-[calc(100vh-22rem)] lg:min-h-[320px] lg:overflow-y-auto lg:overscroll-contain"
+                  className="course-list lg:max-h-[calc(100vh-22rem)] lg:min-h-[320px] lg:overflow-y-auto lg:overscroll-contain"
                 >
                   {filteredCourses.map(course => (
                     <CourseRow
@@ -1800,7 +2060,7 @@ function AppContent() {
                           setWishlistModalMode('list');
                           setShowWishlistModal(true);
                         }}
-                        className="icon-btn"
+                        className="icon-btn h-10 w-10"
                         title="위시리스트 확장 보기"
                         aria-label="위시리스트 확장 보기"
                       >
@@ -1901,9 +2161,14 @@ function AppContent() {
             </div>
           </aside>
         </div>
+        </>
       </div>
       {/* Footer */}
-      <footer className="mt-12 border-t border-slate-200 bg-white">
+      <footer
+        aria-hidden={hasBlockingOverlay}
+        inert={hasBlockingOverlay ? '' : undefined}
+        className="mt-12 border-t border-slate-200 bg-white"
+      >
         <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-7 sm:flex-row sm:items-center sm:justify-between md:px-8">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
             <span className="grid h-6 w-6 place-items-center rounded-md bg-blue-600 text-white">
@@ -1913,6 +2178,13 @@ function AppContent() {
             <span className="text-xs text-slate-400">인천대학교 비공식 서비스 · © 2026</span>
           </div>
           <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setShowDeveloperNotes(true)}
+              className="btn-ghost h-8 px-2.5 text-xs text-slate-500"
+            >
+              <Info size={13} /> 개발 노트
+            </button>
             <a href="/admin/subjects" className="btn-ghost h-8 px-2.5 text-xs text-slate-500">
               <Settings size={13} /> 과목 관리
             </a>

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -77,7 +77,7 @@ const Pagination = ({
           onClick={handlePrevious}
           disabled={currentPage === 0 || isLoading}
           aria-label="이전 페이지"
-          className="btn-secondary h-8 px-2.5 text-[13px]"
+          className="btn-secondary h-10 px-3 text-[13px] sm:h-8 sm:px-2.5"
         >
           <ChevronLeft size={14} />
           <span className="hidden sm:inline">이전</span>
@@ -96,7 +96,7 @@ const Pagination = ({
                 disabled={isLoading}
                 aria-label={`${page + 1}페이지`}
                 aria-current={page === currentPage ? 'page' : undefined}
-                className={`grid h-8 w-8 place-items-center rounded-lg text-[13px] font-medium tabular-nums transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                className={`grid h-10 w-10 place-items-center rounded-lg text-[13px] font-medium tabular-nums transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:h-8 sm:w-8 ${
                   page === currentPage
                     ? 'bg-blue-600 font-semibold text-white'
                     : 'text-slate-600 hover:bg-slate-100'
@@ -112,7 +112,7 @@ const Pagination = ({
           onClick={handleNext}
           disabled={currentPage === totalPages - 1 || isLoading}
           aria-label="다음 페이지"
-          className="btn-secondary h-8 px-2.5 text-[13px]"
+          className="btn-secondary h-10 px-3 text-[13px] sm:h-8 sm:px-2.5"
         >
           <span className="hidden sm:inline">다음</span>
           <ChevronRight size={14} />

--- a/src/components/TimetableCombinationResults.jsx
+++ b/src/components/TimetableCombinationResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useId } from 'react';
 import { ChevronLeft, ChevronRight, Calendar, Clock, User, BookOpen, Award, X, Check, MessageSquare } from 'lucide-react';
 
 import {
@@ -75,8 +75,9 @@ const TimeSlotCell = ({ day, slot, index, grid }) => {
   }
 };
 
-const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) => {
+const TimetableCombinationResults = ({ results, onClose, onSelectCombination, isApplying = false }) => {
   const [currentCombination, setCurrentCombination] = useState(0);
+  const titleId = useId();
 
   if (!results || !results.combinations || results.combinations.length === 0) {
     return null;
@@ -146,10 +147,12 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
   }, [combination]);
 
   const handlePrevious = () => {
+    if (isApplying) return;
     setCurrentCombination(prev => Math.max(0, prev - 1));
   };
 
   const handleNext = () => {
+    if (isApplying) return;
     setCurrentCombination(prev => Math.min(results.combinations.length - 1, prev + 1));
   };
 
@@ -184,19 +187,27 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 sm:p-4 backdrop-blur-sm">
       {/* Mobile: Full screen / Desktop: Centered card */}
-      <div className="modal-panel flex w-full h-[100svh] sm:h-auto sm:max-h-[90vh] sm:max-w-5xl lg:max-w-6xl flex-col overflow-hidden bg-white sm:rounded-2xl sm:ring-1 sm:ring-slate-200 shadow-2xl">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-busy={isApplying}
+        className="modal-panel flex w-full h-[100svh] sm:h-auto sm:max-h-[90vh] sm:max-w-5xl lg:max-w-6xl flex-col overflow-hidden bg-white sm:rounded-2xl sm:ring-1 sm:ring-slate-200 shadow-2xl"
+      >
 
         {/* Header */}
         <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3 sm:px-6 sm:py-5">
           <div className="min-w-0">
-            <h2 className="text-lg sm:text-2xl font-semibold text-slate-900 truncate">시간표 조합</h2>
+            <h2 id={titleId} className="text-lg sm:text-2xl font-semibold text-slate-900 truncate">시간표 조합</h2>
             <p className="mt-0.5 text-xs sm:text-sm text-slate-500">
               {results.totalCount}개 중 {currentCombination + 1}번째
             </p>
           </div>
           <button
             onClick={onClose}
-            className="flex-shrink-0 rounded-full p-2 text-slate-500 transition-colors hover:bg-slate-100"
+            disabled={isApplying}
+            className="icon-btn h-10 w-10 flex-shrink-0"
+            aria-label="시간표 조합 결과 닫기"
           >
             <X size={22} />
           </button>
@@ -207,7 +218,7 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
           <div className="grid gap-4 sm:gap-6 lg:grid-cols-3">
             {/* Timetable Grid */}
             <div className="lg:col-span-2">
-              <div className="rounded-xl sm:rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:p-5">
+              <div className="rounded-xl sm:rounded-2xl border border-slate-200 bg-white p-3 sm:p-4">
                 <div className="mb-3 sm:mb-4 flex items-center gap-2 text-slate-700">
                   <Calendar size={18} className="text-slate-400" />
                   <span className="text-sm sm:text-base font-semibold text-slate-900">
@@ -216,7 +227,7 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
                 </div>
                 {/* Horizontal scroll wrapper for mobile */}
                 <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0">
-                  <div className="min-w-[320px] sm:min-w-0 overflow-hidden rounded-lg sm:rounded-xl border border-slate-200 bg-white shadow-sm">
+                  <div className="min-w-[320px] sm:min-w-0 overflow-hidden rounded-lg sm:rounded-xl border border-slate-200 bg-white">
                     <table className="w-full table-fixed border-collapse text-[10px] sm:text-xs text-slate-700">
                       <colgroup>
                         <col className="w-8 sm:w-10" />
@@ -269,17 +280,22 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
 
                 {/* Unscheduled / Online Courses */}
                 {unscheduledCourses.length > 0 && (
-                  <div className="mt-4 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-                    <h4 className="mb-2 text-xs font-semibold text-slate-500">온라인 · 시간 미지정</h4>
-                    <div className="grid grid-cols-1 gap-2">
+                  <div className="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white">
+                    <div className="border-b border-slate-100 px-3 py-2">
+                      <h4 className="text-xs font-semibold text-slate-500">온라인 · 시간 미지정</h4>
+                    </div>
+                    <div className="course-list">
                       {unscheduledCourses.map(({ subject, colorScheme }, idx) => (
                         <div
                           key={subject.id || idx}
-                          className={`flex items-center justify-between p-2 rounded-lg border ${colorScheme.bg} ${colorScheme.border} ${colorScheme.text}`}
+                          className="course-list-row py-2.5"
                         >
                           <div className="min-w-0 pr-2">
-                            <div className="text-[10px] font-bold truncate">{subject.subjectName}</div>
-                            <div className="text-[9px] opacity-80 truncate">온라인 과목</div>
+                            <div className="truncate text-xs font-semibold text-slate-900">{subject.subjectName}</div>
+                            <div className="mt-1 flex items-center gap-1.5">
+                              <span className={`course-type-badge ${colorScheme.bg} ${colorScheme.text}`}>{subject.subjectType}</span>
+                              <span className="meta-chip bg-white">온라인</span>
+                            </div>
                           </div>
                         </div>
                       ))}
@@ -292,39 +308,45 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
             {/* Subject List & Stats */}
             <div className="space-y-4 sm:space-y-6">
               {/* Subject List */}
-              <div className="rounded-xl sm:rounded-2xl border border-slate-200 bg-white p-3 sm:p-4 shadow-sm">
-                <div className="mb-3 sm:mb-4 flex items-center gap-2 text-slate-700">
+              <div className="overflow-hidden rounded-xl sm:rounded-2xl border border-slate-200 bg-white shadow-sm">
+                <div className="flex items-center gap-2 border-b border-slate-100 px-3 py-3 text-slate-700 sm:px-4">
                   <BookOpen size={18} className="text-slate-400" />
                   <span className="text-sm sm:text-base font-semibold text-slate-900">과목 목록</span>
                 </div>
-                <div className="max-h-48 sm:max-h-60 space-y-2 sm:space-y-3 overflow-y-auto">
+                <div className="course-list max-h-56 overflow-y-auto sm:max-h-64">
                   {combination.map((subject) => {
                     const colorClass = getCourseTypeBadgeClass(subject.subjectType);
 
                     return (
-                      <div key={subject.id} className="rounded-lg sm:rounded-xl border border-slate-200 p-2 sm:p-3">
-                        <div className="flex items-start justify-between gap-2">
+                      <div key={subject.id} className="course-list-row">
+                        <div className="flex items-start justify-between gap-3">
                           <div className="flex-1 min-w-0">
-                            <div className="mb-1 flex flex-wrap items-center gap-1.5">
-                              <span className="text-sm font-semibold text-slate-900 truncate">{subject.subjectName}</span>
-                              <span className={`flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colorClass}`}>{subject.subjectType}</span>
+                            <div className="flex flex-wrap items-center gap-1.5">
+                              <span className="truncate text-sm font-semibold text-slate-900">{subject.subjectName}</span>
+                              <span className={`course-type-badge ${colorClass}`}>{subject.subjectType}</span>
+                              <span className="meta-chip flex-shrink-0 bg-white">{subject.credits}학점</span>
                             </div>
-                            <div className="space-y-0.5 text-xs text-slate-600">
-                              <div className="flex items-center gap-1"><User size={10} className="text-slate-400" />{subject.professor}</div>
-                              <div className="flex items-center gap-1 truncate"><Clock size={10} className="text-slate-400" />{formatTimeDisplay(subject)}</div>
+                            <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-slate-600">
+                              <span className="inline-flex min-w-0 items-center gap-1 truncate">
+                                <User size={11} className="flex-shrink-0 text-slate-400" />
+                                <span className="truncate">{subject.professor}</span>
+                              </span>
+                              <span className="meta-chip min-w-0 bg-white">
+                                <Clock size={11} className="flex-shrink-0 text-slate-400" />
+                                <span className="truncate">{formatTimeDisplay(subject)}</span>
+                              </span>
                             </div>
                             <div className="mt-1.5">
                               <a
                                 href={`https://everytime.kr/lecture/search?keyword=${encodeURIComponent(subject.subjectName)}&condition=name`}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="inline-flex items-center gap-1 text-[10px] text-green-600 hover:text-green-700 font-medium transition-colors"
+                                className="action-chip-link"
                               >
-                                <MessageSquare size={10} /> 강의평 보기
+                                <MessageSquare size={11} /> 강의평
                               </a>
                             </div>
                           </div>
-                          <div className="flex-shrink-0 text-xs sm:text-sm font-medium text-slate-700">{subject.credits}학점</div>
                         </div>
                       </div>
                     );
@@ -333,17 +355,17 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
               </div>
 
               {/* Stats - Hidden on very small screens */}
-              <div className="hidden sm:block rounded-xl sm:rounded-2xl border border-slate-200 bg-white p-3 sm:p-4 shadow-sm">
-                <div className="mb-3 sm:mb-4 flex items-center gap-2 text-slate-700">
+              <div className="hidden overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm sm:block sm:rounded-2xl">
+                <div className="flex items-center gap-2 border-b border-slate-100 px-4 py-3 text-slate-700">
                   <Award size={18} className="text-slate-400" />
                   <span className="text-sm sm:text-base font-semibold text-slate-900">통계</span>
                 </div>
-                <div className="space-y-2 sm:space-y-3 text-xs sm:text-sm text-slate-600">
-                  <div className="flex items-center justify-between border-b border-slate-200 pb-2">
+                <div className="space-y-2 p-4 text-xs sm:text-sm text-slate-600">
+                  <div className="flex items-center justify-between border-b border-slate-100 pb-2">
                     <span>총 학점</span>
                     <span className="font-semibold text-slate-900">{stats.totalCredits}학점</span>
                   </div>
-                  <div className="flex items-center justify-between border-b border-slate-200 pb-2">
+                  <div className="flex items-center justify-between border-b border-slate-100 pb-2">
                     <span>과목 수</span>
                     <span className="font-semibold text-slate-900">{stats.subjectCount}개</span>
                   </div>
@@ -370,16 +392,16 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
           <div className="flex items-center gap-2 order-2 sm:order-1">
             <button
               onClick={handlePrevious}
-              disabled={currentCombination === 0}
-              className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={currentCombination === 0 || isApplying}
+              className="btn-secondary h-9 px-3 text-xs sm:h-10 sm:px-4 sm:text-sm"
             >
               <ChevronLeft size={14} /> 이전
             </button>
             <span className="text-xs sm:text-sm text-slate-500 min-w-[60px] text-center">{currentCombination + 1} / {results.combinations.length}</span>
             <button
               onClick={handleNext}
-              disabled={currentCombination === results.combinations.length - 1}
-              className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={currentCombination === results.combinations.length - 1 || isApplying}
+              className="btn-secondary h-9 px-3 text-xs sm:h-10 sm:px-4 sm:text-sm"
             >
               다음 <ChevronRight size={14} />
             </button>
@@ -389,15 +411,26 @@ const TimetableCombinationResults = ({ results, onClose, onSelectCombination }) 
           <div className="flex gap-2 sm:gap-3 w-full sm:w-auto order-1 sm:order-2">
             <button
               onClick={onClose}
-              className="flex-1 sm:flex-none rounded-full border border-slate-300 px-4 py-2 text-xs sm:text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100"
+              disabled={isApplying}
+              className="btn-secondary h-11 flex-1 text-sm sm:h-10 sm:flex-none"
             >
               닫기
             </button>
             <button
               onClick={handleSelectThis}
-              className="flex-1 sm:flex-none inline-flex items-center justify-center gap-1.5 rounded-full bg-blue-600 px-4 sm:px-5 py-2 text-xs sm:text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500"
+              disabled={isApplying}
+              className="btn-primary h-11 flex-1 text-sm sm:h-10 sm:flex-none"
             >
-              <Check size={14} /> 이 조합 선택
+              {isApplying ? (
+                <>
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  적용 중
+                </>
+              ) : (
+                <>
+                  <Check size={14} /> 이 조합 선택
+                </>
+              )}
             </button>
           </div>
         </div>

--- a/src/components/TimetableListModal.jsx
+++ b/src/components/TimetableListModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import { X, Clock, User, BookOpen, Trash2, Heart, Info, MessageSquare, LayoutList, Grid } from 'lucide-react';
 import TimetableGrid from './TimetableGrid';
 
@@ -52,6 +52,7 @@ const TimetableListModal = ({
   onExportPDF
 }) => {
   const [viewMode, setViewMode] = useState('list'); // 'list' | 'grid'
+  const titleId = useId();
 
   if (!isOpen) return null;
 
@@ -60,16 +61,22 @@ const TimetableListModal = ({
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 sm:p-4 backdrop-blur-sm">
       {/* Mobile: Full screen / Desktop: Centered card */}
-      <div className="modal-panel flex w-full h-[100svh] sm:h-auto sm:max-h-[90vh] sm:max-w-4xl flex-col overflow-hidden bg-white sm:rounded-2xl sm:ring-1 sm:ring-slate-200 shadow-2xl">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="modal-panel flex w-full h-[100svh] sm:h-auto sm:max-h-[90vh] sm:max-w-4xl flex-col overflow-hidden bg-white sm:rounded-2xl sm:ring-1 sm:ring-slate-200 shadow-2xl"
+      >
         <div className="sticky top-0 z-10 flex flex-col border-b border-slate-200 bg-white">
           <div className="flex items-center justify-between px-4 py-4 sm:px-6 sm:py-5">
             <div className="min-w-0">
-              <h2 className="text-lg sm:text-2xl font-semibold text-slate-900 truncate">내 시간표</h2>
+              <h2 id={titleId} className="text-lg sm:text-2xl font-semibold text-slate-900 truncate">내 시간표</h2>
               <p className="mt-0.5 sm:mt-1 text-xs sm:text-sm text-slate-500">총 {courses.length}개 과목 • {totalCredits}학점</p>
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 rounded-full p-2 text-slate-500 transition-colors hover:bg-slate-100"
+              className="icon-btn h-10 w-10 flex-shrink-0"
+              aria-label="내 시간표 닫기"
             >
               <X size={22} />
             </button>
@@ -80,14 +87,14 @@ const TimetableListModal = ({
             <div className="flex w-full rounded-lg bg-slate-100 p-1">
               <button
                 onClick={() => setViewMode('list')}
-                className={`flex flex-1 items-center justify-center gap-2 rounded-md py-1.5 text-xs font-medium transition-all ${viewMode === 'list' ? 'bg-white text-blue-600 shadow-sm' : 'text-slate-500 hover:text-slate-700'}`}
+                className={`flex h-10 flex-1 items-center justify-center gap-2 rounded-md text-xs font-medium transition-all ${viewMode === 'list' ? 'bg-white text-blue-600 shadow-sm' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <LayoutList size={14} />
                 목록 보기
               </button>
               <button
                 onClick={() => setViewMode('grid')}
-                className={`flex flex-1 items-center justify-center gap-2 rounded-md py-1.5 text-xs font-medium transition-all ${viewMode === 'grid' ? 'bg-white text-blue-600 shadow-sm' : 'text-slate-500 hover:text-slate-700'}`}
+                className={`flex h-10 flex-1 items-center justify-center gap-2 rounded-md text-xs font-medium transition-all ${viewMode === 'grid' ? 'bg-white text-blue-600 shadow-sm' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Grid size={14} />
                 시간표 보기
@@ -103,20 +110,20 @@ const TimetableListModal = ({
               <p className="mt-2 text-xs sm:text-sm text-slate-400">과목을 검색해서 시간표에 담아보세요.</p>
             </div>
           ) : viewMode === 'list' ? (
-            <div className="space-y-3 sm:space-y-4">
+            <ul className="course-list overflow-hidden rounded-xl border border-slate-200 bg-white">
               {courses.map((course, index) => (
-                <div
+                <li
                   key={course.id || index}
-                  className="rounded-xl p-3 ring-1 ring-slate-200 bg-white transition-colors hover:ring-slate-300 sm:p-4"
+                  className="course-list-row"
                 >
                   <div className="flex items-start justify-between gap-3 sm:gap-4">
                     <div className="flex-1 min-w-0">
                       <div className="mb-2 flex flex-wrap items-center gap-2 sm:gap-3">
                         <h3 className="text-base sm:text-lg font-semibold text-slate-900 truncate">{course.name}</h3>
-                        <span className={`flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] sm:text-xs font-semibold ${course.color} ${course.textColor}`}>
+                        <span className={`course-type-badge ${course.color} ${course.textColor}`}>
                           {course.type}
                         </span>
-                        <span className="flex-shrink-0 rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] sm:text-xs font-medium text-blue-700">
+                        <span className="meta-chip flex-shrink-0 bg-white text-blue-700">
                           {course.credits}학점
                         </span>
                       </div>
@@ -132,48 +139,52 @@ const TimetableListModal = ({
                         </div>
                       </div>
 
-                      <div className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm text-blue-600">
+                      <div className="meta-chip w-fit max-w-full bg-white text-blue-600">
                         <Clock size={14} className="flex-shrink-0" />
-                        <span className="font-medium">{formatTimeDisplay(course)}</span>
+                        <span className="truncate font-medium">{formatTimeDisplay(course)}</span>
                       </div>
                     </div>
 
-                    <div className="ml-auto flex items-center gap-1 sm:gap-2">
+                    <div className="ml-auto grid grid-cols-2 gap-1 sm:flex sm:items-center sm:gap-2">
                       <a
                         href={`https://everytime.kr/lecture/search?keyword=${encodeURIComponent(course.name)}&condition=name`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="rounded-full p-1.5 sm:p-2 text-slate-500 transition-colors hover:bg-green-100 hover:text-green-700"
+                        className="icon-btn h-10 w-10 hover:bg-green-100 hover:text-green-700 sm:h-8 sm:w-8"
                         title="강의평 보기"
+                        aria-label={`${course.name} 강의평 보기`}
                       >
                         <MessageSquare size={14} className="sm:w-4 sm:h-4" />
                       </a>
                       <button
                         onClick={() => onViewCourseDetails(course)}
-                        className="rounded-full p-1.5 sm:p-2 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                        className="icon-btn h-10 w-10 sm:h-8 sm:w-8"
                         title="상세 정보 보기"
+                        aria-label={`${course.name} 상세 정보 보기`}
                       >
                         <Info size={14} className="sm:w-4 sm:h-4" />
                       </button>
                       <button
                         onClick={() => onAddToWishlist(course)}
-                        className="rounded-full p-1.5 sm:p-2 text-slate-500 transition-colors hover:bg-slate-100 hover:text-blue-600"
+                        className="icon-btn h-10 w-10 hover:text-blue-600 sm:h-8 sm:w-8"
                         title="위시리스트에 담기"
+                        aria-label={`${course.name} 위시리스트에 담기`}
                       >
                         <Heart size={14} className="sm:w-4 sm:h-4" />
                       </button>
                       <button
                         onClick={() => onRemoveCourse(course)}
-                        className="rounded-full p-1.5 sm:p-2 text-slate-500 transition-colors hover:bg-slate-100 hover:text-rose-600"
+                        className="icon-btn h-10 w-10 hover:text-rose-600 sm:h-8 sm:w-8"
                         title="시간표에서 제거"
+                        aria-label={`${course.name} 시간표에서 제거`}
                       >
                         <Trash2 size={14} className="sm:w-4 sm:h-4" />
                       </button>
                     </div>
                   </div>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           ) : (
             <div className="h-full">
               <TimetableGrid
@@ -197,7 +208,7 @@ const TimetableListModal = ({
             </div>
             <button
               onClick={onClose}
-              className="rounded-full border border-slate-300 px-4 py-1.5 sm:px-5 sm:py-2 text-xs sm:text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100"
+              className="btn-secondary h-10 px-4 text-xs sm:px-5 sm:text-sm"
             >
               닫기
             </button>

--- a/src/components/WishlistModal.jsx
+++ b/src/components/WishlistModal.jsx
@@ -100,10 +100,10 @@ const WishlistModal = ({
                 <button
                   type="button"
                   onClick={() => setStep('list')}
-                  className="inline-flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100"
+                  className="btn-secondary h-10 px-3 text-sm"
                   aria-label="위시리스트 목록으로 돌아가기"
                 >
-                  <ChevronLeft size={22} className="text-slate-600" />
+                  <ChevronLeft size={18} className="text-slate-500" />
                   <span className="hidden sm:inline">목록으로</span>
                 </button>
               )}
@@ -122,7 +122,7 @@ const WishlistModal = ({
             <button
               type="button"
               onClick={handleClose}
-              className="flex-shrink-0 rounded-full p-2 text-slate-500 transition-colors hover:bg-slate-100"
+              className="icon-btn h-10 w-10 flex-shrink-0"
               aria-label="위시리스트 닫기"
             >
               <X size={22} />
@@ -135,12 +135,11 @@ const WishlistModal = ({
           {step === 'list' ? (
             // --- List View ---
             wishlist.length > 0 ? (
-              <div className="space-y-3 sm:space-y-4">
+              <ul className="course-list overflow-hidden rounded-xl border border-slate-200 bg-white">
                 {wishlist.map(course => (
-                  <div
+                  <li
                     key={course.id}
-                    className={`rounded-xl p-3 sm:p-4 ring-1 transition-colors ${course.isRequired ? 'bg-rose-50/70 ring-rose-200' : 'bg-white ring-slate-200'
-                      }`}
+                    className={`course-list-row ${course.isRequired ? 'bg-rose-50/70' : ''}`}
                   >
                     {/* Course Header */}
                     <div className="mb-2 sm:mb-3 flex items-start justify-between gap-2">
@@ -154,7 +153,8 @@ const WishlistModal = ({
                       </div>
                       <button
                         onClick={() => onViewCourseDetails(course)}
-                        className="flex-shrink-0 inline-flex items-center justify-center gap-1 rounded-lg border border-slate-300 bg-white px-2 py-1 sm:px-3 sm:py-1.5 text-xs sm:text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+                        className="icon-btn h-10 w-10 flex-shrink-0 bg-white ring-1 ring-inset ring-slate-200 sm:h-8 sm:w-auto sm:px-3"
+                        aria-label={`${course.name} 상세 정보 보기`}
                       >
                         <Info size={14} className="sm:w-4 sm:h-4" />
                         <span className="hidden sm:inline">상세보기</span>
@@ -162,63 +162,62 @@ const WishlistModal = ({
                     </div>
 
                     {/* Course Info */}
-                    <div className="mb-2 sm:mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs sm:text-sm text-slate-600">
-                      <div className="flex items-center gap-1.5">
+                    <div className="mb-2 sm:mb-3 flex flex-wrap items-center gap-1.5 text-xs sm:text-sm text-slate-600">
+                      <div className="meta-chip bg-white">
                         <Star size={14} className="text-amber-500" />
                         <span>{course.credits}학점</span>
                       </div>
-                      <span className="font-medium text-slate-700">{course.professor}</span>
+                      <span className="min-w-0 truncate font-medium text-slate-700">{course.professor}</span>
                     </div>
 
-                    <div className="mb-2 sm:mb-3 flex items-start gap-1.5 text-xs sm:text-sm text-blue-600">
-                      <Clock size={14} className="mt-0.5 flex-shrink-0" />
-                      <span className="font-medium">{formatTimeDisplay(course)}</span>
+                    <div className="mb-2 sm:mb-3 meta-chip w-fit max-w-full bg-white text-blue-600">
+                      <Clock size={14} className="flex-shrink-0" />
+                      <span className="truncate font-medium">{formatTimeDisplay(course)}</span>
                     </div>
 
                     {/* Required Checkbox */}
-                    <div className="mb-2 sm:mb-3 flex items-center gap-2">
+                    <label
+                      htmlFor={`required-modal-${course.id}`}
+                      className="mb-2 flex min-h-10 w-fit cursor-pointer items-center gap-2 rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600 ring-1 ring-slate-200 transition-colors hover:bg-slate-100 sm:mb-3 sm:text-sm"
+                    >
                       <input
                         type="checkbox"
                         id={`required-modal-${course.id}`}
                         checked={course.isRequired || false}
                         onChange={() => onToggleRequired(course.id, course.isRequired)}
-                        className="h-4 w-4 rounded border border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0"
+                        className="h-5 w-5 rounded border border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0"
                       />
-                      <label
-                        htmlFor={`required-modal-${course.id}`}
-                        className="cursor-pointer text-xs sm:text-sm text-slate-600"
-                      >
-                        필수 포함 과목
-                      </label>
-                    </div>
+                      <span>필수 포함 과목</span>
+                    </label>
 
                     {/* Action Buttons */}
-                    <div className="flex flex-wrap gap-2 border-t border-slate-200 pt-2 sm:pt-3">
+                    <div className="grid grid-cols-[1fr_1fr_2.75rem] gap-2 border-t border-slate-200 pt-2 sm:flex sm:pt-3">
                       <a
                         href={`https://everytime.kr/lecture/search?keyword=${encodeURIComponent(course.name)}&condition=name`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="btn-secondary h-9 px-3 text-xs sm:text-sm"
+                        className="btn-secondary h-11 px-3 text-xs sm:h-9 sm:text-sm"
                       >
                         <MessageSquare size={14} className="text-emerald-500" /> 강의평
                       </a>
                       <button
                         onClick={() => onAddToTimetable(course)}
-                        className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-xs sm:text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500"
+                        className="btn-primary h-11 px-3 text-xs sm:h-9 sm:flex-1 sm:text-sm"
                       >
                         <Plus size={14} /> 시간표 추가
                       </button>
                       <button
                         onClick={() => onRemoveFromWishlist(course.id)}
-                        className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-rose-300 bg-white px-3 py-2 text-xs sm:text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50"
+                        className="icon-btn h-11 w-11 text-rose-600 ring-1 ring-inset ring-rose-200 hover:bg-rose-50 sm:h-9 sm:w-auto sm:px-3"
+                        aria-label={`${course.name} 위시리스트에서 제거`}
                       >
                         <Trash2 size={14} />
                         <span className="hidden sm:inline">제거</span>
                       </button>
                     </div>
-                  </div>
+                  </li>
                 ))}
-              </div>
+              </ul>
             ) : (
               <div className="rounded-xl sm:rounded-2xl border border-dashed border-slate-200 bg-slate-50 py-10 sm:py-12 text-center">
                 <h3 className="text-base sm:text-lg font-medium text-slate-600">위시리스트가 비어있어요</h3>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -69,6 +69,14 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
+  const createDevSession = async (options = {}) => {
+    const payload = await authAPI.createDevSession(options);
+    const devUser = payload?.user || payload;
+    setUser(devUser);
+    localStorage.setItem('user', JSON.stringify(devUser));
+    return payload;
+  };
+
   const logout = async () => {
     try {
       await authAPI.logout();
@@ -85,6 +93,7 @@ export const AuthProvider = ({ children }) => {
     isLoading,
     login,
     register,
+    createDevSession,
     logout,
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 @layer base {
   body {
     @apply bg-slate-50 text-slate-900 antialiased;
-    letter-spacing: -0.01em;
+    letter-spacing: 0;
   }
 
   ::selection {
@@ -15,11 +15,39 @@
 
 @layer components {
   .btn-primary {
-    @apply inline-flex h-9 items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 active:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-blue-300 disabled:shadow-none;
+    @apply inline-flex h-9 items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3.5 text-sm font-semibold text-white ring-1 ring-inset ring-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-blue-300 disabled:shadow-none disabled:ring-transparent;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+    transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    @apply bg-blue-500;
+    box-shadow: 0 8px 18px rgba(37, 99, 235, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    transform: translateY(-1px);
+  }
+
+  .btn-primary:active:not(:disabled) {
+    @apply bg-blue-700;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+    transform: translateY(0);
   }
 
   .btn-secondary {
-    @apply inline-flex h-9 items-center justify-center gap-1.5 rounded-lg bg-white px-3.5 text-sm font-medium text-slate-700 ring-1 ring-inset ring-slate-200 transition-colors hover:bg-slate-50 active:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50;
+    @apply inline-flex h-9 items-center justify-center gap-1.5 rounded-lg bg-white px-3.5 text-sm font-medium text-slate-700 ring-1 ring-inset ring-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50;
+    box-shadow: 0 1px 1px rgba(15, 23, 42, 0.04);
+    transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    @apply bg-slate-50 text-slate-900;
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.08);
+    transform: translateY(-1px);
+  }
+
+  .btn-secondary:active:not(:disabled) {
+    @apply bg-slate-100;
+    box-shadow: 0 1px 1px rgba(15, 23, 42, 0.04);
+    transform: translateY(0);
   }
 
   .btn-ghost {
@@ -35,11 +63,70 @@
   }
 
   .card {
-    @apply rounded-2xl bg-white ring-1 ring-slate-200;
+    @apply rounded-2xl bg-white shadow-sm shadow-slate-900/5 ring-1 ring-slate-200;
+  }
+
+  .course-list {
+    @apply divide-y divide-slate-100;
+  }
+
+  .course-list-row {
+    @apply relative px-4 py-3 transition-colors sm:px-5 sm:py-2.5;
+  }
+
+  .course-list-row::before {
+    content: '';
+    @apply absolute bottom-2 left-0 top-2 w-0.5 rounded-r-full bg-blue-500 opacity-0 transition-opacity;
+  }
+
+  .course-type-badge {
+    @apply inline-flex flex-shrink-0 items-center rounded-md px-1.5 py-0.5 text-[11px] font-semibold ring-1 ring-inset ring-black/5;
+  }
+
+  .meta-chip {
+    @apply inline-flex max-w-full items-center gap-1 rounded-md bg-slate-50 px-1.5 py-0.5 text-xs font-medium text-slate-600 ring-1 ring-inset ring-slate-200/80;
+  }
+
+  .action-chip-link {
+    @apply inline-flex h-7 items-center justify-center gap-1 rounded-md bg-emerald-50 px-2 text-[11px] font-medium text-emerald-700 ring-1 ring-inset ring-emerald-100 transition-colors hover:bg-emerald-100 hover:text-emerald-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500;
+  }
+
+  .select-trigger {
+    @apply flex h-11 items-center justify-between rounded-xl bg-slate-50/70 pr-3 text-left text-[13px] shadow-inner shadow-slate-100/60 hover:bg-white disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400 disabled:shadow-none sm:h-9;
+  }
+
+  .select-trigger-active {
+    @apply border-blue-200 bg-blue-50/80 font-medium text-blue-700 shadow-blue-100/50;
+  }
+
+  .select-menu {
+    @apply absolute left-0 right-0 top-[calc(100%+6px)] z-50 overflow-hidden rounded-2xl border border-slate-200 bg-white py-1 shadow-xl shadow-slate-900/10 ring-1 ring-slate-900/5;
+  }
+
+  .select-menu-wide {
+    @apply min-w-[16rem] max-w-[calc(100vw-2rem)];
+  }
+
+  .select-option {
+    @apply flex w-full items-center justify-between gap-2 rounded-xl px-3 py-2 text-left text-[13px] text-slate-600 transition-colors hover:bg-slate-50 hover:text-slate-900;
+  }
+
+  .select-option-active {
+    @apply bg-blue-50 font-semibold text-blue-700;
   }
 
   .modal-panel {
     animation: modal-pop 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .course-list-row:hover {
+    background: linear-gradient(90deg, rgba(239, 246, 255, 0.82), rgba(255, 255, 255, 0));
+  }
+
+  .course-list-row:hover::before {
+    @apply opacity-100;
   }
 }
 
@@ -60,5 +147,12 @@
   ::after {
     animation-duration: 0.01ms !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .btn-primary:hover:not(:disabled),
+  .btn-secondary:hover:not(:disabled),
+  .btn-primary:active:not(:disabled),
+  .btn-secondary:active:not(:disabled) {
+    transform: none;
   }
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,5 +1,6 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 const ADMIN_BASE_URL = import.meta.env.VITE_ADMIN_API_BASE_URL || '/admin/api';
+const DEFAULT_SEMESTER = '2026-1';
 
 // API 응답 처리 헬퍼
 const handleResponse = async (response) => {
@@ -45,12 +46,21 @@ const readCookie = (name) => {
   return cookie ? decodeURIComponent(cookie.slice(encodedName.length)) : '';
 };
 
+const clearCookie = (name) => {
+  document.cookie = `${encodeURIComponent(name)}=; Max-Age=0; path=/`;
+};
+
 const fetchWithUserSession = (url, options = {}) => fetch(url, {
   ...options,
   credentials: 'include',
 });
 
 let csrfTokenPromise = null;
+
+const resetUserCsrfToken = () => {
+  csrfTokenPromise = null;
+  clearCookie('XSRF-TOKEN');
+};
 
 const getUserCsrfToken = async () => {
   const cookieToken = readCookie('XSRF-TOKEN');
@@ -77,13 +87,39 @@ const getUserCsrfToken = async () => {
 
 const fetchWithUserCsrf = async (url, options = {}) => {
   const csrfToken = await getUserCsrfToken();
-  return fetchWithUserSession(url, {
+  const requestOptions = {
     ...options,
     headers: {
       ...(options.headers || {}),
       'X-XSRF-TOKEN': csrfToken,
     },
+  };
+
+  const response = await fetchWithUserSession(url, requestOptions);
+  if (response.status !== 403) {
+    return response;
+  }
+
+  resetUserCsrfToken();
+  const refreshedToken = await getUserCsrfToken();
+  return fetchWithUserSession(url, {
+    ...options,
+    headers: {
+      ...(options.headers || {}),
+      'X-XSRF-TOKEN': refreshedToken,
+    },
   });
+};
+
+const handleUserSessionMutationResponse = async (response) => {
+  try {
+    const payload = await handleResponse(response);
+    resetUserCsrfToken();
+    return payload;
+  } catch (error) {
+    resetUserCsrfToken();
+    throw error;
+  }
 };
 
 const getAdminHeaders = (csrfToken) => ({
@@ -243,7 +279,7 @@ export const authAPI = {
       },
       body: JSON.stringify(userData),
     });
-    return handleResponse(response);
+    return handleUserSessionMutationResponse(response);
   },
 
   // 로그인
@@ -255,7 +291,18 @@ export const authAPI = {
       },
       body: JSON.stringify(credentials),
     });
-    return handleResponse(response);
+    return handleUserSessionMutationResponse(response);
+  },
+
+  createDevSession: async ({ semester, seedWishlist = true, reset = false } = {}) => {
+    const response = await fetchWithUserSession(`${BASE_URL}/dev/session`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ semester, seedWishlist, reset }),
+    });
+    return handleUserSessionMutationResponse(response);
   },
 
   me: async () => {
@@ -267,7 +314,7 @@ export const authAPI = {
     const response = await fetchWithUserCsrf(`${BASE_URL}/auth/logout`, {
       method: 'POST',
     });
-    return handleResponse(response);
+    return handleUserSessionMutationResponse(response);
   },
 };
 
@@ -286,7 +333,7 @@ export const wishlistAPI = {
   },
 
   // 위시리스트 조회
-  getByUser: async (userId, semester = '2024-2') => {
+  getByUser: async (userId, semester = DEFAULT_SEMESTER) => {
     const response = await fetchWithUserSession(`${BASE_URL}/wishlist/user/${userId}?semester=${semester}`);
     return handleResponse(response);
   },
@@ -339,7 +386,7 @@ export const timetableAPI = {
   },
 
   // 개인 시간표 조회
-  getByUser: async (userId, semester = '2024-2') => {
+  getByUser: async (userId, semester = DEFAULT_SEMESTER) => {
     const response = await fetchWithUserSession(`${BASE_URL}/timetable/user/${userId}?semester=${semester}`);
     return handleResponse(response);
   },
@@ -383,7 +430,7 @@ export const combinationAPI = {
 // 과목 통계 API
 export const statisticsAPI = {
   // 과목별 참여자 통계 조회
-  getSubjectStats: async (subjectId, semester = '2024-2') => {
+  getSubjectStats: async (subjectId, semester = DEFAULT_SEMESTER) => {
     if (!subjectId) {
       throw new Error('과목 ID가 필요합니다.');
     }

--- a/src/utils/timetableUtils.js
+++ b/src/utils/timetableUtils.js
@@ -1,4 +1,4 @@
-export const CURRENT_SEMESTER = '2024-2';
+export const CURRENT_SEMESTER = '2026-1';
 
 export const convertToPeriod = (timeValue) => {
     const PERIOD_START_HOUR_OFFSET = 8;


### PR DESCRIPTION
## 요약
- 검색 결과를 카드형에서 한 줄 리스트 중심의 서비스형 UI로 정리했습니다.
- 드롭다운, 페이지네이션, 위시리스트/시간표/조합 결과 모달의 모바일 터치 영역과 밀도를 개선했습니다.
- footer에 `개발 노트` 버튼을 추가해 방학 중 개선 내용을 날짜별로 확인할 수 있게 했습니다.
- 기본 학기 값을 현재 과목 기준인 `2026-1`로 맞추고, 개발 환경 전용 디자인 QA 세션 진입 흐름을 연결했습니다.

## 제외 범위
- 인기 랭킹 화면과 mock 랭킹 데이터는 이번 PR에서 제외했습니다.
- 랭킹은 실제 집계 API가 준비된 뒤 별도 PR로 다루는 편이 안전합니다.

## 검증
- `npm run build`
- `git diff --check`
- 로컬 브라우저에서 footer `개발 노트` 버튼 및 모달 표시 확인
- 랭킹 관련 코드 노출 여부 검색 확인: `rg "RankingView|mockRanking|인기 랭킹|RANKING_" src` 결과 없음

## 메모
- 디자인 QA 세션 버튼은 Vite 개발 환경에서만 보입니다.
- 백엔드 dev/local 세션 엔드포인트가 함께 있을 때 샘플 위시리스트를 채운 상태로 UI를 확인할 수 있습니다.